### PR TITLE
Implements mock test access control

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sarthak-student-app",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sarthak-student-app",
-      "version": "3.0.6",
+      "version": "3.0.7",
       "dependencies": {
         "@iconify/react": "^5.2.0",
         "@pkasila/react-katex": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sarthak-student-app",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/dashboard/mockTest/[mockTestId]/page.jsx
+++ b/src/app/dashboard/mockTest/[mockTestId]/page.jsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import {
   appwriteDatabases,
   downloadMockTest,
@@ -11,11 +11,12 @@ import { ID, Query } from "appwrite";
 import { Button } from "@/components/ui/button";
 import { useAppContent } from "@/hook/app/useAppContent";
 import { useAuthContext } from "@/hook/auth/useAuthContext";
+import { labels } from "@/lib/labels";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Progress } from "@/components/ui/progress";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { CloudIcon } from "lucide-react";
+import { CloudIcon, Lock, AlertTriangle, Home, ArrowLeft } from "lucide-react";
 import { PATH_DASHBOARD } from "@/routes/paths";
 import {
   LineChart,
@@ -39,11 +40,18 @@ import {
 
 export default function MockTestPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { setCurrentPageName } = useAppContent();
   const { user } = useAuthContext();
   const [mockTestId, setMockTestId] = useState(
     window.location.pathname.split("/")[3]
   );
+
+  // Get productId from search parameters
+  const productId = searchParams.get("productId");
+
+  // Check if user has subscription for this product
+  const [hasSubscription, setHasSubscription] = useState(false);
 
   const [loading, setLoading] = useState(false);
   const [attempts, setAttempts] = useState([]);
@@ -55,6 +63,19 @@ export default function MockTestPage() {
   useEffect(() => {
     // Fetch mock test details and attempts
     const fetchMockTestAndAttempts = async () => {
+      const c =
+        user &&
+        productId &&
+        user.labels.findIndex(
+          (label) =>
+            label === labels.founder ||
+            label === labels.admin ||
+            label === productId
+        ) !== -1;
+      setHasSubscription(c);
+      if (!c) {
+        return;
+      }
       const id = window.location.pathname.split("/")[3];
       setMockTestId(id);
       try {
@@ -143,6 +164,73 @@ export default function MockTestPage() {
       createNewAttempt();
     }
   };
+
+  // Check if productId is null or user doesn't have subscription - show blocked access page
+  if (!productId || !hasSubscription) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-red-50 via-white to-red-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
+        <div className="max-w-md w-full mx-4">
+          <Card className="p-8 text-center shadow-2xl border-red-200 dark:border-red-800 bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm">
+            <div className="flex justify-center mb-6">
+              <div className="relative">
+                <div className="w-20 h-20 bg-red-100 dark:bg-red-900/30 rounded-full flex items-center justify-center">
+                  <Lock className="w-10 h-10 text-red-600 dark:text-red-400" />
+                </div>
+                <div className="absolute -top-2 -right-2 w-8 h-8 bg-red-500 rounded-full flex items-center justify-center">
+                  <AlertTriangle className="w-4 h-4 text-white" />
+                </div>
+              </div>
+            </div>
+
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+              Access Blocked
+            </h1>
+
+            <p className="text-gray-600 dark:text-gray-300 mb-6 leading-relaxed">
+              {!productId
+                ? "You don't have permission to access this mock test. This content requires a valid mock test series subscription."
+                : "You don't have an active subscription for this mock test series. Please purchase the series to access this content."}
+            </p>
+
+            <div className="space-y-3">
+              {productId && (
+                <Button
+                  onClick={() => router.push(`/product/${productId}`)}
+                  className="w-full bg-blue-600 hover:bg-blue-700 text-white"
+                >
+                  <Home className="w-4 h-4 mr-2" />
+                  View Product Details
+                </Button>
+              )}
+
+              <Button
+                onClick={() => router.push(PATH_DASHBOARD.root)}
+                className="w-full bg-red-600 hover:bg-red-700 text-white"
+              >
+                <Home className="w-4 h-4 mr-2" />
+                Go to Dashboard
+              </Button>
+
+              <Button
+                onClick={() => router.back()}
+                variant="outline"
+                className="w-full border-red-200 text-red-600 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-900/20"
+              >
+                <ArrowLeft className="w-4 h-4 mr-2" />
+                Go Back
+              </Button>
+            </div>
+
+            <div className="mt-6 pt-6 border-t border-gray-200 dark:border-gray-700">
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Need help? Contact support for assistance.
+              </p>
+            </div>
+          </Card>
+        </div>
+      </div>
+    );
+  }
 
   if (loading) {
     return (

--- a/src/app/product/[productId]/page.js
+++ b/src/app/product/[productId]/page.js
@@ -252,7 +252,11 @@ export default function ProductViewPage() {
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-2 mt-1 mb-1">
             {product?.mockTest?.map((test) => (
-              <MockTestCard mockTestId={test} key={test} />
+              <MockTestCard
+                mockTestId={test}
+                key={test}
+                productId={productId}
+              />
             ))}
           </div>
         </div>

--- a/src/components/sections/dashboard/mock-test-card.jsx
+++ b/src/components/sections/dashboard/mock-test-card.jsx
@@ -7,7 +7,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { downloadMockTest } from "@/hook/auth/AppwriteContext";
 import { ArrowUpRight } from "lucide-react";
 
-export default function MockTestCard({ mockTestId }) {
+export default function MockTestCard({ mockTestId, productId }) {
   const [loading, setLoading] = useState(true);
   const [mockTest, setMockTest] = useState({});
   const [isDownloaded, setIsDownloaded] = useState(false);
@@ -30,7 +30,9 @@ export default function MockTestCard({ mockTestId }) {
       title={!isDownloaded ? "Downloading test content..." : "Start test"}
     >
       <Link
-        href={isDownloaded ? PATH_DASHBOARD.mockTest(mockTestId) : "#"}
+        href={
+          isDownloaded ? PATH_DASHBOARD.mockTest(mockTestId, productId) : "#"
+        }
         className={`group ${!isDownloaded ? "pointer-events-none" : ""}`}
       >
         <div

--- a/src/components/sections/dashboard/test-attempt.jsx
+++ b/src/components/sections/dashboard/test-attempt.jsx
@@ -129,6 +129,7 @@ export default function TestAttempt({ attemptObj }) {
           status: TEST_STATUS.IN_EVALUATION,
           test_ended_by: actionBy,
           test_ended: new Date(),
+          evaluationDate: new Date(),
         }
       );
 

--- a/src/components/sections/dashboard/test-evaluation.jsx
+++ b/src/components/sections/dashboard/test-evaluation.jsx
@@ -1,6 +1,9 @@
 import { APPWRITE_API } from "@/config-global";
 import { useAppContent } from "@/hook/app/useAppContent";
-import { appwriteFunction } from "@/hook/auth/AppwriteContext";
+import {
+  appwriteDatabases,
+  appwriteFunction,
+} from "@/hook/auth/AppwriteContext";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
@@ -28,7 +31,7 @@ export default function TestEvaluation({ attempt }) {
 
   useEffect(() => {
     // Get test end time from attempt object
-    const testEndTime = attempt?.test_ended || new Date().getTime();
+    const testEndTime = attempt?.$updatedAt || new Date().getTime();
 
     // Check every minute if 15 minutes have passed
     const interval = setInterval(() => {
@@ -52,8 +55,17 @@ export default function TestEvaluation({ attempt }) {
     return () => clearInterval(interval);
   }, [attempt]);
 
-  const handleReEvaluate = () => {
+  const handleReEvaluate = async () => {
     try {
+      await appwriteDatabases.updateDocument(
+        APPWRITE_API.databaseId,
+        APPWRITE_API.collections.mockTestAttempts,
+        attempt?.$id,
+        {
+          evaluationDate: new Date(),
+        }
+      );
+
       appwriteFunction.createExecution(
         APPWRITE_API.functions.sarthakAPI,
         JSON.stringify({
@@ -64,10 +76,10 @@ export default function TestEvaluation({ attempt }) {
       );
 
       toast.success("Re-evaluation started successfully");
+      setShowReEvaluate(false);
     } catch (error) {
       toast.error(error.message);
     }
-    setShowReEvaluate(false);
   };
 
   return (

--- a/src/routes/paths.js
+++ b/src/routes/paths.js
@@ -26,7 +26,8 @@ export const PATH_DASHBOARD = {
   profile: path(ROOTS_DASHBOARD, "/profile"),
   purchased: path(ROOTS_DASHBOARD, "/purchased"),
   attempt: (attemptId) => path(ROOTS_DASHBOARD, `/attempt/${attemptId}`),
-  mockTest: (mockTestId) => path(ROOTS_DASHBOARD, `/mockTest/${mockTestId}`),
+  mockTest: (mockTestId, productId) =>
+    path(ROOTS_DASHBOARD, `/mockTest/${mockTestId}?productId=${productId}`),
   orders: {
     root: path(ROOTS_DASHBOARD, "/orders"),
     view: (id) => path(ROOTS_DASHBOARD, `/orders/${id}`),


### PR DESCRIPTION
Adds access control to mock tests based on product subscriptions.

This change ensures that users can only access mock tests if they have a valid subscription for the associated product. It introduces a check for subscription status before allowing access to the mock test page. If the user doesn't have a subscription or the product ID is missing, an "Access Blocked" page is displayed, guiding the user to product details or the dashboard.

Also, this commit includes a minor update to the test attempt evaluation logic to re-evaluate tests.

Implements mock test access control

Adds access control to mock tests based on product subscriptions.

This change ensures that users can only access mock tests if they have a valid subscription for the associated product. It introduces a check for subscription status before allowing access to the mock test page. If the user doesn't have a subscription or the product ID is missing, an "Access Blocked" page is displayed, guiding the user to product details or the dashboard.

Also updates test attempt evaluation logic to allow re-evaluation of tests.